### PR TITLE
feat: add commercial edition prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All user-visible changes to Web2UI — Copy for Figma are recorded here.
 
+## Unreleased
+
+- Added an optional Web2UI Cloud website link, with contextual suggestions when local capture uses
+  fidelity approximations or fails because the page is too complex for the public profile.
+- Kept the commercial handoff user-initiated and link-only: no capture data, account state, or
+  conversion request is sent by the extension.
+
 ## 0.1.0 — 2026-07-23
 
 - Published the browser-safe capture contracts, DOM extractor, canonical conversion, and clipboard

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -32,6 +32,14 @@ The extension does not use telemetry, analytics, advertising identifiers, crash 
 remote feature flags, or remotely hosted executable code. The maintainers do not sell captured
 content or use it for advertising.
 
+## Commercial edition link
+
+The popup contains an optional link to the separate Web2UI Cloud website and may repeat that link
+when local conversion reports a fidelity approximation or complexity-related failure. The site is
+opened only after the user clicks the link. No captured page content, RenderPlan, clipboard
+payload, account identifier, or conversion state is transferred by the extension. The destination
+receives the ordinary request metadata sent by Chrome and is governed by its own privacy policy.
+
 ## Clipboard and Figma
 
 The extension writes the result to the system clipboard only after the user clicks **Copy for

--- a/README.md
+++ b/README.md
@@ -130,7 +130,10 @@ The commercial product extends Web2UI with:
 - an expanded fidelity path for complex and dynamic pages, backed by managed cloud processing.
 
 The hosted product is separate from this repository. No Web2UI account or commercial service is
-required to install, build, modify, or use the open-source extension.
+required to install, build, modify, or use the open-source extension. The extension includes an
+optional website link and may show it beside a local fidelity warning or complexity-related
+failure. Following that link is always a separate user action: the extension does not upload the
+capture, create an account, or send conversion data to the hosted product.
 
 ## Install
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,9 @@ adds public license/install/source metadata and produces a checksum and SPDX SBO
 - Canvas, video, WebGL, unsupported SVG, and browser-only effects use the bounded
   `local-static-v1` single-frame fallback profile.
 - The extension captures one viewport/theme combination and stores one current result.
-- There is no migration path to or dependency on a hosted product.
+- There is no capture-data migration path to or runtime dependency on a hosted product. The popup
+  may open the separately hosted commercial website after an explicit user click, but does not
+  call its APIs or transfer capture state.
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for change guidance and [TESTING.md](TESTING.md) for the
 verification map.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -96,4 +96,5 @@ a Web2UI host. The browser profile and screenshots are disposable and must not b
   file alone.
 - **Release-boundary failure:** read the reported file and pattern. Do not relax a rule merely to
   pass; confirm whether the change violates local-only scope, manifest policy, or artifact
-  hygiene.
+  hygiene. The reviewed commercial website link is allowlisted only in its source component and
+  compiled popup; popup network primitives and the same origin elsewhere still fail closed.

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -6,6 +6,11 @@ const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const target = path.resolve(root, process.argv[2] ?? "dist");
 
 const allowedRuntimeDependencies = new Set(["react", "react-dom"]);
+const commercialWebsiteUrl = "https://web2ui.lynavo.io/";
+const commercialWebsiteLinkFiles = new Set([
+  "src/extension/popup/commercial-edition.tsx",
+  "dist/popup.js",
+]);
 
 const forbiddenSourcePatterns = [
   /web2ui\.lynavo\.io/iu,
@@ -71,19 +76,34 @@ async function assertNoServerBoundary(directory) {
     }
     if (!/\.(?:css|html|js|json|md|mjs|svg|ts|tsx|txt|xml)$/u.test(file)) continue;
     const contents = await readFile(file, "utf8").catch(() => "");
+    const relative = path.relative(root, file).split(path.sep).join("/");
     if (/sourceMappingURL|sourceURL|sourcesContent|webpack:\/\//u.test(contents)) {
       offenders.push(`${path.relative(root, file)} (source map metadata)`);
       continue;
     }
-    const match = forbiddenSourcePatterns.find((pattern) => pattern.test(contents));
+    const boundaryContents = stripReviewedCommercialWebsiteLink(relative, contents);
+    const match = forbiddenSourcePatterns.find((pattern) => pattern.test(boundaryContents));
     const releaseMatch = forbiddenReleasePatterns.find((pattern) => pattern.test(contents));
-    if (match || releaseMatch) {
-      offenders.push(`${path.relative(root, file)} (${(match ?? releaseMatch).source})`);
+    const popupNetworkMatch =
+      relative === "dist/popup.js"
+        ? /\b(?:fetch\s*\(|XMLHttpRequest|WebSocket|EventSource)\b/u.exec(contents)
+        : null;
+    if (match || releaseMatch || popupNetworkMatch) {
+      offenders.push(
+        `${path.relative(root, file)} (${(match ?? releaseMatch)?.source ?? "popup network primitive"})`,
+      );
     }
   }
   if (offenders.length > 0) {
     throw new Error(`server boundary violation:\n${offenders.join("\n")}`);
   }
+}
+
+function stripReviewedCommercialWebsiteLink(relative, contents) {
+  if (!commercialWebsiteLinkFiles.has(relative)) return contents;
+  const occurrences = contents.split(commercialWebsiteUrl).length - 1;
+  if (occurrences !== 1) return contents;
+  return contents.replace(commercialWebsiteUrl, "");
 }
 
 async function assertManifest(directory) {

--- a/src/extension/popup/app.tsx
+++ b/src/extension/popup/app.tsx
@@ -12,6 +12,10 @@ import {
   type ViewportChoice,
 } from "./capture-options.js";
 import { writeFigmaClipboardPayload } from "./clipboard.js";
+import {
+  CommercialEditionLink,
+  canSuggestManagedRecovery,
+} from "./commercial-edition.js";
 
 type CopyStatus = "idle" | "copying" | "copied" | "error";
 
@@ -40,6 +44,11 @@ export function PopupView(props: PopupViewProps) {
           <img className="brand-logo" src="icons/icon-48.png" alt="" draggable={false} />
           <span className="brand-name">Web2UI</span>
         </div>
+        <CommercialEditionLink
+          className="commercial-header-link"
+          label="Web2UI Cloud"
+          ariaLabel="Open the commercial Web2UI Cloud edition in a new tab"
+        />
       </header>
 
       {ready ? (
@@ -64,9 +73,16 @@ function CapturePanel(props: PopupViewProps) {
       {error ? (
         <div className="error-banner" role="alert">
           <span className="error-dot">!</span>
-          <div>
+          <div className="error-content">
             <div className="error-title">Capture failed</div>
             <div className="error-detail">{error.message}</div>
+            {canSuggestManagedRecovery(error.code) ? (
+              <CommercialEditionLink
+                className="error-commercial-link"
+                label="Try managed capture in Web2UI Cloud"
+                ariaLabel="Try managed capture in the commercial Web2UI Cloud edition"
+              />
+            ) : null}
           </div>
         </div>
       ) : null}
@@ -278,7 +294,14 @@ function ReadyPanel(props: PopupViewProps) {
       </section>
 
       {warningCount > 0 ? (
-        <p className="warning-note">{warningCount} visual detail{warningCount === 1 ? "" : "s"} used a safe approximation.</p>
+        <div className="warning-note" role="note">
+          <span>{warningCount} visual detail{warningCount === 1 ? "" : "s"} used a safe approximation.</span>
+          <CommercialEditionLink
+            className="warning-commercial-link"
+            label="Higher fidelity with Web2UI Cloud"
+            ariaLabel="Explore higher-fidelity managed capture in the commercial Web2UI Cloud edition"
+          />
+        </div>
       ) : null}
 
       <button

--- a/src/extension/popup/commercial-edition.tsx
+++ b/src/extension/popup/commercial-edition.tsx
@@ -1,0 +1,37 @@
+import type { ExtensionErrorCode } from "../state-machine.js";
+
+export const COMMERCIAL_EDITION_URL = "https://web2ui.lynavo.io/";
+
+const MANAGED_RECOVERY_ERROR_CODES: ReadonlySet<ExtensionErrorCode> = new Set([
+  "capture-failed",
+  "invalid-capture",
+  "conversion-failed",
+  "plan-too-large",
+]);
+
+export function canSuggestManagedRecovery(code: ExtensionErrorCode): boolean {
+  return MANAGED_RECOVERY_ERROR_CODES.has(code);
+}
+
+export function CommercialEditionLink({
+  className,
+  label,
+  ariaLabel,
+}: {
+  className: string;
+  label: string;
+  ariaLabel: string;
+}) {
+  return (
+    <a
+      className={`commercial-edition-link ${className}`}
+      href={COMMERCIAL_EDITION_URL}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={ariaLabel}
+    >
+      <span>{label}</span>
+      <span className="commercial-link-arrow" aria-hidden="true">↗</span>
+    </a>
+  );
+}

--- a/src/extension/popup/styles.css
+++ b/src/extension/popup/styles.css
@@ -99,6 +99,49 @@ button:disabled {
   line-height: 1.2;
 }
 
+.commercial-edition-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+}
+
+.commercial-link-arrow {
+  display: inline-block;
+  transition: transform 0.15s;
+}
+
+.commercial-edition-link:hover .commercial-link-arrow {
+  transform: translate(1px, -1px);
+}
+
+.commercial-header-link {
+  min-height: 27px;
+  padding: 0 9px;
+  border: 1px solid rgba(79, 70, 229, 0.16);
+  border-radius: 999px;
+  background: #f8f7ff;
+  color: var(--accent);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.commercial-header-link:hover {
+  border-color: rgba(79, 70, 229, 0.32);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+
+.commercial-header-link:focus-visible,
+.error-commercial-link:focus-visible,
+.warning-commercial-link:focus-visible {
+  border-radius: 6px;
+  outline: 3px solid rgba(79, 70, 229, 0.28);
+  outline-offset: 2px;
+}
+
 .main {
   display: flex;
   min-height: 0;
@@ -138,6 +181,10 @@ button:disabled {
   font-weight: 900;
 }
 
+.error-content {
+  min-width: 0;
+}
+
 .error-title {
   color: #7f1d1d;
   font-size: 11px;
@@ -150,6 +197,21 @@ button:disabled {
   font-size: 9.5px;
   font-weight: 500;
   line-height: 1.4;
+}
+
+.error-commercial-link {
+  margin-top: 5px;
+  color: #991b1b;
+  font-size: 9.5px;
+  font-weight: 800;
+  text-decoration: underline;
+  text-decoration-color: rgba(153, 27, 27, 0.28);
+  text-underline-offset: 2px;
+}
+
+.error-commercial-link:hover {
+  color: #7f1d1d;
+  text-decoration-color: currentColor;
 }
 
 .env-card {
@@ -699,15 +761,28 @@ button:disabled {
 }
 
 .warning-note {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
   margin: -12px 0 12px;
-  padding: 8px 10px;
+  padding: 9px 11px;
   border: 1px solid #fde68a;
   border-radius: 10px;
   background: #fffbeb;
   color: #92400e;
   font-size: 9.5px;
   line-height: 1.35;
-  text-align: center;
+  text-align: left;
+}
+
+.warning-commercial-link {
+  color: var(--accent);
+  font-weight: 800;
+}
+
+.warning-commercial-link:hover {
+  color: var(--accent-hover);
 }
 
 .result-copy-card {

--- a/tests/e2e/fixtures/local-page.html
+++ b/tests/e2e/fixtures/local-page.html
@@ -35,6 +35,18 @@
         background: linear-gradient(160deg, #ff5f40 0 48%, #172033 48% 100%);
         box-shadow: 22px 24px 0 rgba(23, 32, 51, .18);
       }
+      .warning-sample {
+        display: grid;
+        width: 28px;
+        height: 28px;
+        margin-top: 12px;
+        place-items: center;
+        background: rgba(255, 255, 255, .7);
+        color: #172033;
+        font: 700 10px/1 system-ui, sans-serif;
+        writing-mode: vertical-rl;
+        text-orientation: upright;
+      }
       main { padding: 88px 80px; }
       .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; }
       .card {
@@ -67,6 +79,7 @@
       <div>
         <h1>Local pages, editable ideas.</h1>
         <p class="lede">A deterministic fixture for browser-only capture, conversion, and clipboard rendering.</p>
+        <span class="warning-sample">UI</span>
       </div>
       <div class="poster" aria-label="Abstract poster"></div>
     </header>

--- a/tests/e2e/local-copy-flow.test.ts
+++ b/tests/e2e/local-copy-flow.test.ts
@@ -96,6 +96,19 @@ describe.sequential("real MV3 local Copy for Figma flow", () => {
         state: "visible",
         timeout: 30_000,
       });
+      const readyState = await popup.evaluate(async () => {
+        return chrome.runtime.sendMessage({ type: "get-state" }) as Promise<{
+          ok: true;
+          state: { status: string; warningCount?: number };
+        }>;
+      });
+      expect(readyState.state.warningCount).toBeGreaterThan(0);
+      const fidelityLink = popup.getByRole("link", {
+        name: "Explore higher-fidelity managed capture in the commercial Web2UI Cloud edition",
+      });
+      await fidelityLink.waitFor({ state: "visible", timeout: 5_000 });
+      expect(await fidelityLink.getAttribute("href")).toBe("https://web2ui.lynavo.io/");
+      expect(await fidelityLink.getAttribute("target")).toBe("_blank");
       await popup.screenshot({ path: path.join(artifacts, "visible-ready-popup.png") });
       await popup.getByRole("button", { name: "Copy for Figma" }).click();
       await popup.getByRole("button", { name: "Copied — paste in Figma" }).waitFor({

--- a/tests/popup-view.test.tsx
+++ b/tests/popup-view.test.tsx
@@ -50,6 +50,10 @@ describe("PopupView", () => {
     expect(markup).toContain("Capture visible area");
     expect(markup).toContain("Browser viewport");
     expect(markup).toContain("Browser theme");
+    expect(markup).toContain("Web2UI Cloud");
+    expect(markup).toContain('href="https://web2ui.lynavo.io/"');
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('rel="noreferrer"');
     expect(markup).not.toMatch(/Selection|Send to Figma|Sign in|credits?/iu);
   });
 
@@ -108,9 +112,27 @@ describe("PopupView", () => {
     expect(markup).toContain("Capture another page");
     expect(markup).toContain("Clear local data");
     expect(markup).toContain("Stored locally for up to 24 hours");
+    expect(markup).toContain("2 visual details used a safe approximation.");
+    expect(markup).toContain("Higher fidelity with Web2UI Cloud");
     expect(markup).toMatch(/class="[^"]*\bresult-view\b[^"]*"/u);
     expect(markup).toContain('class="result-copy-card"');
     expect(markup).toContain('class="result-card-arrow"');
     expect(markup).not.toMatch(/upload|account|plugin/iu);
+  });
+
+  it("suggests managed capture only for local complexity failures", () => {
+    const complexMarkup = render({
+      status: "error",
+      code: "plan-too-large",
+      message: "The page was too complex to convert locally.",
+    });
+    const permissionMarkup = render({
+      status: "error",
+      code: "permission-denied",
+      message: "Chrome denied access to this page.",
+    });
+
+    expect(complexMarkup).toContain("Try managed capture in Web2UI Cloud");
+    expect(permissionMarkup).not.toContain("Try managed capture in Web2UI Cloud");
   });
 });

--- a/tests/release-boundary.test.mjs
+++ b/tests/release-boundary.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { copyFile, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
@@ -19,6 +19,23 @@ test("accepts the local-only source and extension bundle", () => {
 
   const result = verify("dist");
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
+test("allows only an explicit user-directed commercial website link in the popup", async () => {
+  const component = await readFile(
+    new URL("../src/extension/popup/commercial-edition.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(component, /href=\{COMMERCIAL_EDITION_URL\}/u);
+  assert.match(component, /target="_blank"/u);
+  assert.match(component, /rel="noreferrer"/u);
+  assert.doesNotMatch(component, /\b(?:fetch\s*\(|XMLHttpRequest|WebSocket|EventSource)\b/u);
+
+  const build = spawnSync("pnpm", ["run", "build"], { cwd: root, encoding: "utf8" });
+  assert.equal(build.status, 0, `${build.stdout}\n${build.stderr}`);
+  const popup = await readFile(new URL("../dist/popup.js", import.meta.url), "utf8");
+  assert.equal(popup.split("https://web2ui.lynavo.io/").length - 1, 1);
+  assert.doesNotMatch(popup, /\b(?:fetch\s*\(|XMLHttpRequest|WebSocket|EventSource)\b/u);
 });
 
 test("rejects server control-plane code from a release bundle", async () => {


### PR DESCRIPTION
## Summary
- add a subtle Web2UI Cloud website link to the popup header
- show contextual higher-fidelity guidance for approximation warnings
- suggest managed capture only for complexity-related local failures
- keep the handoff link-only with no capture upload, API call, telemetry, or new permission
- tighten release verification around the single reviewed website link

## Validation
- pnpm audit
- pnpm validate
- pnpm package
- real MV3 warning-state screenshot reviewed at 380×580

## Privacy and permissions
- no permission changes
- no automatic network request to Web2UI Cloud
- README, PRIVACY, architecture, testing guidance, and changelog updated